### PR TITLE
Update to the URL

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,16 +16,15 @@ default['ovirt']['db_password']            = 'dbpassword'
 default['ovirt']['db_host']                = 'localhost'
 default['ovirt']['db_port']                = '5432'
 default['ovirt']['answers_file']           = '/var/lib/ovirt-engine/setup/answers/answers-from-chef'
-default['ovirt']['ovirt_release_base_url'] = 'http://ovirt.org/releases'
+default['ovirt']['ovirt_release_base_url'] = 'http://plain.resources.ovirt.org/pub/yum-repo'
+default['ovirt']['ovirt_release_rpm']      = 'ovirt-release36.rpm'
 default['ovirt']['supported_platforms']    = %w{ centos fedora redhat }
-  
+
 case node['platform']
   when 'centos', 'redhat'
     default['ovirt']['firewall_manager']   = 'iptables'
-    default['ovirt']['ovirt_release_rpm']  = 'ovirt-release-el.noarch.rpm'
   when 'fedora'
     default['ovirt']['firewall_manager']   = 'firewalld'
-    default['ovirt']['ovirt_release_rpm']  = 'ovirt-release-fedora.noarch.rpm'
 end
 
 default['ovirt']['ovirt_release_rpm_url']  = "#{node['ovirt']['ovirt_release_base_url']}/#{node['ovirt']['ovirt_release_rpm']}"

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Jason Cannon'
 maintainer_email 'jason@thisidig.com'
 description      'Installs/Configures ovirt'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.1'
+version          '0.1.2'
 
 %w{ centos fedora redhat }.each do |os|
   supports os

--- a/recipes/engine.rb
+++ b/recipes/engine.rb
@@ -17,7 +17,7 @@ end
 template node['ovirt']['answers_file'] do
   source 'answers.erb'
 end
-  
+
 bash 'engine-setup' do
   user 'root'
   path ['/usr/bin', '/bin', '/sbin', '/usr/sbin']


### PR DESCRIPTION
-The release RPM package for Fedora and EL are now the same so no need to differentiate.
-Updated the URL to the release RPM, with 36 being the latest.
-Remove spaces
